### PR TITLE
Move all the pixel computations to `Sprite::compute_pixel_space_point`.

### DIFF
--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -76,7 +76,8 @@ use bevy_window::{PrimaryWindow, RawHandleWrapperHolder};
 use extract_resource::ExtractResourcePlugin;
 use globals::GlobalsPlugin;
 use render_asset::RenderAssetBytesPerFrame;
-use renderer::{RenderAdapter, RenderAdapterInfo, RenderDevice, RenderQueue};
+use renderer::{RenderDevice, RenderQueue};
+use settings::RenderResources;
 use sync_world::{
     despawn_temporary_render_entities, entity_sync_system, SyncToRenderWorld, SyncWorldPlugin,
 };
@@ -95,7 +96,7 @@ use crate::{
 use alloc::sync::Arc;
 use bevy_app::{App, AppLabel, Plugin, SubApp};
 use bevy_asset::{load_internal_asset, AssetApp, AssetServer, Handle};
-use bevy_ecs::{prelude::*, schedule::ScheduleLabel, system::SystemState};
+use bevy_ecs::{prelude::*, schedule::ScheduleLabel};
 use bevy_utils::tracing::debug;
 use core::ops::{Deref, DerefMut};
 use std::sync::Mutex;
@@ -240,19 +241,7 @@ pub mod graph {
 }
 
 #[derive(Resource)]
-struct FutureRendererResources(
-    Arc<
-        Mutex<
-            Option<(
-                RenderDevice,
-                RenderQueue,
-                RenderAdapterInfo,
-                RenderAdapter,
-                RenderInstance,
-            )>,
-        >,
-    >,
-);
+struct FutureRenderResources(Arc<Mutex<Option<RenderResources>>>);
 
 /// A label for the rendering sub-app.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, AppLabel)]
@@ -271,31 +260,27 @@ impl Plugin for RenderPlugin {
             .init_asset_loader::<ShaderLoader>();
 
         match &self.render_creation {
-            RenderCreation::Manual(device, queue, adapter_info, adapter, instance) => {
-                let future_renderer_resources_wrapper = Arc::new(Mutex::new(Some((
-                    device.clone(),
-                    queue.clone(),
-                    adapter_info.clone(),
-                    adapter.clone(),
-                    instance.clone(),
-                ))));
-                app.insert_resource(FutureRendererResources(
-                    future_renderer_resources_wrapper.clone(),
+            RenderCreation::Manual(resources) => {
+                let future_render_resources_wrapper = Arc::new(Mutex::new(Some(resources.clone())));
+                app.insert_resource(FutureRenderResources(
+                    future_render_resources_wrapper.clone(),
                 ));
                 // SAFETY: Plugins should be set up on the main thread.
                 unsafe { initialize_render_app(app) };
             }
             RenderCreation::Automatic(render_creation) => {
                 if let Some(backends) = render_creation.backends {
-                    let future_renderer_resources_wrapper = Arc::new(Mutex::new(None));
-                    app.insert_resource(FutureRendererResources(
-                        future_renderer_resources_wrapper.clone(),
+                    let future_render_resources_wrapper = Arc::new(Mutex::new(None));
+                    app.insert_resource(FutureRenderResources(
+                        future_render_resources_wrapper.clone(),
                     ));
 
-                    let mut system_state: SystemState<
-                        Query<&RawHandleWrapperHolder, With<PrimaryWindow>>,
-                    > = SystemState::new(app.world_mut());
-                    let primary_window = system_state.get(app.world()).get_single().ok().cloned();
+                    let primary_window = app
+                        .world_mut()
+                        .query_filtered::<&RawHandleWrapperHolder, With<PrimaryWindow>>()
+                        .get_single(app.world())
+                        .ok()
+                        .cloned();
                     let settings = render_creation.clone();
                     let async_renderer = async move {
                         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
@@ -305,13 +290,13 @@ impl Plugin for RenderPlugin {
                             gles_minor_version: settings.gles3_minor_version,
                         });
 
-                        // SAFETY: Plugins should be set up on the main thread.
-                        let surface = primary_window.and_then(|wrapper| unsafe {
+                        let surface = primary_window.and_then(|wrapper| {
                             let maybe_handle = wrapper.0.lock().expect(
                                 "Couldn't get the window handle in time for renderer initialization",
                             );
                             if let Some(wrapper) = maybe_handle.as_ref() {
-                                let handle = wrapper.get_handle();
+                                // SAFETY: Plugins should be set up on the main thread.
+                                let handle = unsafe { wrapper.get_handle() };
                                 Some(
                                     instance
                                         .create_surface(handle)
@@ -337,9 +322,9 @@ impl Plugin for RenderPlugin {
                             .await;
                         debug!("Configured wgpu adapter Limits: {:#?}", device.limits());
                         debug!("Configured wgpu adapter Features: {:#?}", device.features());
-                        let mut future_renderer_resources_inner =
-                            future_renderer_resources_wrapper.lock().unwrap();
-                        *future_renderer_resources_inner = Some((
+                        let mut future_render_resources_inner =
+                            future_render_resources_wrapper.lock().unwrap();
+                        *future_render_resources_inner = Some(RenderResources(
                             device,
                             queue,
                             adapter_info,
@@ -391,7 +376,7 @@ impl Plugin for RenderPlugin {
 
     fn ready(&self, app: &App) -> bool {
         app.world()
-            .get_resource::<FutureRendererResources>()
+            .get_resource::<FutureRenderResources>()
             .and_then(|frr| frr.0.try_lock().map(|locked| locked.is_some()).ok())
             .unwrap_or(true)
     }
@@ -404,11 +389,11 @@ impl Plugin for RenderPlugin {
             "color_operations.wgsl",
             Shader::from_wgsl
         );
-        if let Some(future_renderer_resources) =
-            app.world_mut().remove_resource::<FutureRendererResources>()
+        if let Some(future_render_resources) =
+            app.world_mut().remove_resource::<FutureRenderResources>()
         {
-            let (device, queue, adapter_info, render_adapter, instance) =
-                future_renderer_resources.0.lock().unwrap().take().unwrap();
+            let RenderResources(device, queue, adapter_info, render_adapter, instance) =
+                future_render_resources.0.lock().unwrap().take().unwrap();
 
             app.insert_resource(device.clone())
                 .insert_resource(queue.clone())

--- a/crates/bevy_render/src/render_resource/bind_group.rs
+++ b/crates/bevy_render/src/render_resource/bind_group.rs
@@ -172,7 +172,7 @@ impl Deref for BindGroup {
 ///     * The field's [`Handle<Storage>`](bevy_asset::Handle) will be used to look up the matching [`Buffer`] GPU resource, which
 ///       will be bound as a storage buffer in shaders. If the `storage` attribute is used, the field is expected a raw
 ///       buffer, and the buffer will be bound as a storage buffer in shaders.
-///     * It supports and optional `read_only` parameter. Defaults to false if not present.
+///     * It supports an optional `read_only` parameter. Defaults to false if not present.
 ///
 /// | Arguments              | Values                                                                  | Default              |
 /// |------------------------|-------------------------------------------------------------------------|----------------------|

--- a/crates/bevy_render/src/settings.rs
+++ b/crates/bevy_render/src/settings.rs
@@ -124,16 +124,19 @@ impl Default for WgpuSettings {
     }
 }
 
+#[derive(Clone)]
+pub struct RenderResources(
+    pub RenderDevice,
+    pub RenderQueue,
+    pub RenderAdapterInfo,
+    pub RenderAdapter,
+    pub RenderInstance,
+);
+
 /// An enum describing how the renderer will initialize resources. This is used when creating the [`RenderPlugin`](crate::RenderPlugin).
 pub enum RenderCreation {
     /// Allows renderer resource initialization to happen outside of the rendering plugin.
-    Manual(
-        RenderDevice,
-        RenderQueue,
-        RenderAdapterInfo,
-        RenderAdapter,
-        RenderInstance,
-    ),
+    Manual(RenderResources),
     /// Lets the rendering plugin create resources itself.
     Automatic(WgpuSettings),
 }
@@ -147,7 +150,13 @@ impl RenderCreation {
         adapter: RenderAdapter,
         instance: RenderInstance,
     ) -> Self {
-        Self::Manual(device, queue, adapter_info, adapter, instance)
+        RenderResources(device, queue, adapter_info, adapter, instance).into()
+    }
+}
+
+impl From<RenderResources> for RenderCreation {
+    fn from(value: RenderResources) -> Self {
+        Self::Manual(value)
     }
 }
 

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -41,6 +41,8 @@ use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 pub use bundle::*;
 pub use dynamic_texture_atlas_builder::*;
 pub use mesh2d::*;
+#[cfg(feature = "bevy_sprite_picking_backend")]
+pub use picking_backend::*;
 pub use render::*;
 pub use sprite::*;
 pub use texture_atlas::*;
@@ -148,7 +150,7 @@ impl Plugin for SpritePlugin {
 
         #[cfg(feature = "bevy_sprite_picking_backend")]
         if self.add_picking {
-            app.add_plugins(picking_backend::SpritePickingPlugin);
+            app.add_plugins(SpritePickingPlugin);
         }
 
         if let Some(render_app) = app.get_sub_app_mut(RenderApp) {

--- a/crates/bevy_sprite/src/picking_backend.rs
+++ b/crates/bevy_sprite/src/picking_backend.rs
@@ -147,11 +147,9 @@ fn sprite_picking(
                 }
                 // Otherwise we can interpolate the xy of the start and end positions by the
                 // lerp factor to get the cursor position in sprite space!
-                // We also need to invert the y axis as pixel data handles the y axis differently to world and screen coords
                 let cursor_pos_sprite = cursor_start_sprite
                     .lerp(cursor_end_sprite, lerp_factor)
-                    .xy()
-                    * Vec2::new(1.0, -1.0);
+                    .xy();
 
                 let Ok(cursor_pixel_space) = sprite.compute_pixel_space_point(
                     cursor_pos_sprite,

--- a/crates/bevy_sprite/src/picking_backend.rs
+++ b/crates/bevy_sprite/src/picking_backend.rs
@@ -57,7 +57,7 @@ impl Plugin for SpritePickingPlugin {
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn sprite_picking(
+fn sprite_picking(
     pointers: Query<(&PointerId, &PointerLocation)>,
     cameras: Query<(Entity, &Camera, &GlobalTransform, &OrthographicProjection)>,
     primary_window: Query<Entity, With<PrimaryWindow>>,

--- a/crates/bevy_sprite/src/picking_backend.rs
+++ b/crates/bevy_sprite/src/picking_backend.rs
@@ -31,14 +31,14 @@ pub enum SpritePickingMode {
 /// Runtime settings for the [`SpritePickingPlugin`].
 #[derive(Resource, Reflect)]
 #[reflect(Resource, Default)]
-pub struct SpriteBackendSettings {
+pub struct SpritePickingSettings {
     /// Should the backend count transparent pixels as part of the sprite for picking purposes or should it use the bounding box of the sprite alone.
     ///
     /// Defaults to an incusive alpha threshold of 0.1
     pub picking_mode: SpritePickingMode,
 }
 
-impl Default for SpriteBackendSettings {
+impl Default for SpritePickingSettings {
     fn default() -> Self {
         Self {
             picking_mode: SpritePickingMode::AlphaThreshold(0.1),
@@ -51,7 +51,7 @@ pub struct SpritePickingPlugin;
 
 impl Plugin for SpritePickingPlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<SpriteBackendSettings>()
+        app.init_resource::<SpritePickingSettings>()
             .add_systems(PreUpdate, sprite_picking.in_set(PickSet::Backend));
     }
 }
@@ -63,7 +63,7 @@ fn sprite_picking(
     primary_window: Query<Entity, With<PrimaryWindow>>,
     images: Res<Assets<Image>>,
     texture_atlas_layout: Res<Assets<TextureAtlasLayout>>,
-    settings: Res<SpriteBackendSettings>,
+    settings: Res<SpritePickingSettings>,
     sprite_query: Query<(
         Entity,
         &Sprite,

--- a/crates/bevy_sprite/src/picking_backend.rs
+++ b/crates/bevy_sprite/src/picking_backend.rs
@@ -161,6 +161,9 @@ pub fn sprite_picking(
                     return None;
                 };
 
+                // Since the pixel space coordinate is `Ok`, we know the cursor is in the bounds of
+                // the sprite.
+
                 let cursor_in_valid_pixels_of_sprite = 'valid_pixel: {
                     match settings.picking_mode {
                         SpritePickingMode::AlphaThreshold(cutoff) => {

--- a/crates/bevy_sprite/src/sprite.rs
+++ b/crates/bevy_sprite/src/sprite.rs
@@ -1,13 +1,13 @@
-use bevy_asset::Handle;
+use bevy_asset::{Assets, Handle};
 use bevy_color::Color;
 use bevy_ecs::{component::Component, reflect::ReflectComponent};
 use bevy_image::Image;
-use bevy_math::{Rect, Vec2};
+use bevy_math::{Rect, UVec2, Vec2};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::{sync_world::SyncToRenderWorld, view::Visibility};
 use bevy_transform::components::Transform;
 
-use crate::{TextureAtlas, TextureSlicer};
+use crate::{TextureAtlas, TextureAtlasLayout, TextureSlicer};
 
 /// Describes a sprite to be rendered to a 2D camera
 #[derive(Component, Debug, Default, Clone, Reflect)]
@@ -71,6 +71,73 @@ impl Sprite {
             color: color.into(),
             custom_size: Some(size),
             ..Default::default()
+        }
+    }
+
+    /// Computes the pixel point where `point_relative_to_sprite` is sampled
+    /// from in this sprite. `point_relative_to_sprite` must be in the sprite's
+    /// local frame. Returns an Ok if the point is inside the bounds of the
+    /// sprite (not just the image), and returns an Err otherwise.
+    pub fn compute_pixel_space_point(
+        &self,
+        point_relative_to_sprite: Vec2,
+        images: &Assets<Image>,
+        texture_atlases: &Assets<TextureAtlasLayout>,
+    ) -> Result<Vec2, Vec2> {
+        let image_size = images
+            .get(&self.image)
+            .map(|image| image.size())
+            .unwrap_or(UVec2::ONE);
+
+        let atlas_rect = self
+            .texture_atlas
+            .as_ref()
+            .and_then(|s| s.texture_rect(texture_atlases))
+            .map(|r| r.as_rect());
+        let texture_rect = match (atlas_rect, self.rect) {
+            (None, None) => Rect::new(0.0, 0.0, image_size.x as f32, image_size.y as f32),
+            (None, Some(sprite_rect)) => sprite_rect,
+            (Some(atlas_rect), None) => atlas_rect,
+            (Some(atlas_rect), Some(mut sprite_rect)) => {
+                // Make the sprite rect relative to the atlas rect.
+                sprite_rect.min += atlas_rect.min;
+                sprite_rect.max += atlas_rect.min;
+                sprite_rect
+            }
+        };
+
+        let sprite_size = self.custom_size.unwrap_or_else(|| texture_rect.size());
+        let sprite_center = -self.anchor.as_vec() * sprite_size;
+
+        let mut point_relative_to_sprite_center = point_relative_to_sprite - sprite_center;
+
+        if self.flip_x {
+            point_relative_to_sprite_center.x *= -1.0;
+        }
+        // Texture coordinates start at the top left, whereas world coordinates start at the bottom
+        // left. So flip by default, and then don't flip if `flip_y` is set.
+        if !self.flip_y {
+            point_relative_to_sprite_center.y *= -1.0;
+        }
+
+        let sprite_to_texture_ratio = {
+            let texture_size = texture_rect.size();
+            let div_or_zero = |a, b| if b == 0.0 { 0.0 } else { a / b };
+            Vec2::new(
+                div_or_zero(texture_size.x, sprite_size.x),
+                div_or_zero(texture_size.y, sprite_size.y),
+            )
+        };
+
+        let point_relative_to_texture =
+            point_relative_to_sprite_center * sprite_to_texture_ratio + texture_rect.center();
+
+        // TODO: Support `SpriteImageMode`.
+
+        if texture_rect.contains(point_relative_to_texture) {
+            Ok(point_relative_to_texture)
+        } else {
+            Err(point_relative_to_texture)
         }
     }
 }
@@ -148,5 +215,267 @@ impl Anchor {
             Anchor::TopRight => Vec2::new(0.5, 0.5),
             Anchor::Custom(point) => *point,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bevy_asset::{Assets, RenderAssetUsages};
+    use bevy_color::Color;
+    use bevy_image::Image;
+    use bevy_math::{Rect, URect, UVec2, Vec2};
+    use bevy_render::render_resource::{Extent3d, TextureDimension, TextureFormat};
+
+    use crate::{Anchor, TextureAtlas, TextureAtlasLayout};
+
+    use super::Sprite;
+
+    /// Makes a new image of the specified size.
+    fn make_image(size: UVec2) -> Image {
+        Image::new_fill(
+            Extent3d {
+                width: size.x,
+                height: size.y,
+                depth_or_array_layers: 1,
+            },
+            TextureDimension::D2,
+            &[0, 0, 0, 255],
+            TextureFormat::Rgba8Unorm,
+            RenderAssetUsages::all(),
+        )
+    }
+
+    #[test]
+    fn compute_pixel_space_point_for_regular_sprite() {
+        let mut image_assets = Assets::<Image>::default();
+        let texture_atlas_assets = Assets::<TextureAtlasLayout>::default();
+
+        let image = image_assets.add(make_image(UVec2::new(5, 10)));
+
+        let sprite = Sprite {
+            image,
+            ..Default::default()
+        };
+
+        let compute =
+            |point| sprite.compute_pixel_space_point(point, &image_assets, &texture_atlas_assets);
+        assert_eq!(compute(Vec2::new(-2.0, -4.5)), Ok(Vec2::new(0.5, 9.5)));
+        assert_eq!(compute(Vec2::new(0.0, 0.0)), Ok(Vec2::new(2.5, 5.0)));
+        assert_eq!(compute(Vec2::new(0.0, 4.5)), Ok(Vec2::new(2.5, 0.5)));
+        assert_eq!(compute(Vec2::new(3.0, 0.0)), Err(Vec2::new(5.5, 5.0)));
+        assert_eq!(compute(Vec2::new(-3.0, 0.0)), Err(Vec2::new(-0.5, 5.0)));
+    }
+
+    #[test]
+    fn compute_pixel_space_point_for_color_sprite() {
+        let image_assets = Assets::<Image>::default();
+        let texture_atlas_assets = Assets::<TextureAtlasLayout>::default();
+
+        // This also tests the `custom_size` field.
+        let sprite = Sprite::from_color(Color::BLACK, Vec2::new(50.0, 100.0));
+
+        let compute = |point| {
+            sprite
+                .compute_pixel_space_point(point, &image_assets, &texture_atlas_assets)
+                // Round to remove floating point errors.
+                .map(|x| (x * 1e5).round() / 1e5)
+                .map_err(|x| (x * 1e5).round() / 1e5)
+        };
+        assert_eq!(compute(Vec2::new(-20.0, -40.0)), Ok(Vec2::new(0.1, 0.9)));
+        assert_eq!(compute(Vec2::new(0.0, 10.0)), Ok(Vec2::new(0.5, 0.4)));
+        assert_eq!(compute(Vec2::new(75.0, 100.0)), Err(Vec2::new(2.0, -0.5)));
+        assert_eq!(compute(Vec2::new(-75.0, -100.0)), Err(Vec2::new(-1.0, 1.5)));
+        assert_eq!(compute(Vec2::new(-30.0, -40.0)), Err(Vec2::new(-0.1, 0.9)));
+    }
+
+    #[test]
+    fn compute_pixel_space_point_for_sprite_with_anchor_bottom_left() {
+        let mut image_assets = Assets::<Image>::default();
+        let texture_atlas_assets = Assets::<TextureAtlasLayout>::default();
+
+        let image = image_assets.add(make_image(UVec2::new(5, 10)));
+
+        let sprite = Sprite {
+            image,
+            anchor: Anchor::BottomLeft,
+            ..Default::default()
+        };
+
+        let compute =
+            |point| sprite.compute_pixel_space_point(point, &image_assets, &texture_atlas_assets);
+        assert_eq!(compute(Vec2::new(0.5, 9.5)), Ok(Vec2::new(0.5, 0.5)));
+        assert_eq!(compute(Vec2::new(2.5, 5.0)), Ok(Vec2::new(2.5, 5.0)));
+        assert_eq!(compute(Vec2::new(2.5, 9.5)), Ok(Vec2::new(2.5, 0.5)));
+        assert_eq!(compute(Vec2::new(5.5, 5.0)), Err(Vec2::new(5.5, 5.0)));
+        assert_eq!(compute(Vec2::new(-0.5, 5.0)), Err(Vec2::new(-0.5, 5.0)));
+    }
+
+    #[test]
+    fn compute_pixel_space_point_for_sprite_with_anchor_top_right() {
+        let mut image_assets = Assets::<Image>::default();
+        let texture_atlas_assets = Assets::<TextureAtlasLayout>::default();
+
+        let image = image_assets.add(make_image(UVec2::new(5, 10)));
+
+        let sprite = Sprite {
+            image,
+            anchor: Anchor::TopRight,
+            ..Default::default()
+        };
+
+        let compute =
+            |point| sprite.compute_pixel_space_point(point, &image_assets, &texture_atlas_assets);
+        assert_eq!(compute(Vec2::new(-4.5, -0.5)), Ok(Vec2::new(0.5, 0.5)));
+        assert_eq!(compute(Vec2::new(-2.5, -5.0)), Ok(Vec2::new(2.5, 5.0)));
+        assert_eq!(compute(Vec2::new(-2.5, -0.5)), Ok(Vec2::new(2.5, 0.5)));
+        assert_eq!(compute(Vec2::new(0.5, -5.0)), Err(Vec2::new(5.5, 5.0)));
+        assert_eq!(compute(Vec2::new(-5.5, -5.0)), Err(Vec2::new(-0.5, 5.0)));
+    }
+
+    #[test]
+    fn compute_pixel_space_point_for_sprite_with_anchor_flip_x() {
+        let mut image_assets = Assets::<Image>::default();
+        let texture_atlas_assets = Assets::<TextureAtlasLayout>::default();
+
+        let image = image_assets.add(make_image(UVec2::new(5, 10)));
+
+        let sprite = Sprite {
+            image,
+            anchor: Anchor::BottomLeft,
+            flip_x: true,
+            ..Default::default()
+        };
+
+        let compute =
+            |point| sprite.compute_pixel_space_point(point, &image_assets, &texture_atlas_assets);
+        assert_eq!(compute(Vec2::new(0.5, 9.5)), Ok(Vec2::new(4.5, 0.5)));
+        assert_eq!(compute(Vec2::new(2.5, 5.0)), Ok(Vec2::new(2.5, 5.0)));
+        assert_eq!(compute(Vec2::new(2.5, 9.5)), Ok(Vec2::new(2.5, 0.5)));
+        assert_eq!(compute(Vec2::new(5.5, 5.0)), Err(Vec2::new(-0.5, 5.0)));
+        assert_eq!(compute(Vec2::new(-0.5, 5.0)), Err(Vec2::new(5.5, 5.0)));
+    }
+
+    #[test]
+    fn compute_pixel_space_point_for_sprite_with_anchor_flip_y() {
+        let mut image_assets = Assets::<Image>::default();
+        let texture_atlas_assets = Assets::<TextureAtlasLayout>::default();
+
+        let image = image_assets.add(make_image(UVec2::new(5, 10)));
+
+        let sprite = Sprite {
+            image,
+            anchor: Anchor::TopRight,
+            flip_y: true,
+            ..Default::default()
+        };
+
+        let compute =
+            |point| sprite.compute_pixel_space_point(point, &image_assets, &texture_atlas_assets);
+        assert_eq!(compute(Vec2::new(-4.5, -0.5)), Ok(Vec2::new(0.5, 9.5)));
+        assert_eq!(compute(Vec2::new(-2.5, -5.0)), Ok(Vec2::new(2.5, 5.0)));
+        assert_eq!(compute(Vec2::new(-2.5, -0.5)), Ok(Vec2::new(2.5, 9.5)));
+        assert_eq!(compute(Vec2::new(0.5, -5.0)), Err(Vec2::new(5.5, 5.0)));
+        assert_eq!(compute(Vec2::new(-5.5, -5.0)), Err(Vec2::new(-0.5, 5.0)));
+    }
+
+    #[test]
+    fn compute_pixel_space_point_for_sprite_with_rect() {
+        let mut image_assets = Assets::<Image>::default();
+        let texture_atlas_assets = Assets::<TextureAtlasLayout>::default();
+
+        let image = image_assets.add(make_image(UVec2::new(5, 10)));
+
+        let sprite = Sprite {
+            image,
+            rect: Some(Rect::new(1.5, 3.0, 3.0, 9.5)),
+            anchor: Anchor::BottomLeft,
+            ..Default::default()
+        };
+
+        let compute =
+            |point| sprite.compute_pixel_space_point(point, &image_assets, &texture_atlas_assets);
+        assert_eq!(compute(Vec2::new(0.5, 0.5)), Ok(Vec2::new(2.0, 9.0)));
+        // The pixel is outside the rect, but is still a valid pixel in the image.
+        assert_eq!(compute(Vec2::new(2.0, 2.5)), Err(Vec2::new(3.5, 7.0)));
+    }
+
+    #[test]
+    fn compute_pixel_space_point_for_texture_atlas_sprite() {
+        let mut image_assets = Assets::<Image>::default();
+        let mut texture_atlas_assets = Assets::<TextureAtlasLayout>::default();
+
+        let image = image_assets.add(make_image(UVec2::new(5, 10)));
+        let texture_atlas = texture_atlas_assets.add(TextureAtlasLayout {
+            size: UVec2::new(5, 10),
+            textures: vec![URect::new(1, 1, 4, 4)],
+        });
+
+        let sprite = Sprite {
+            image,
+            anchor: Anchor::BottomLeft,
+            texture_atlas: Some(TextureAtlas {
+                layout: texture_atlas,
+                index: 0,
+            }),
+            ..Default::default()
+        };
+
+        let compute =
+            |point| sprite.compute_pixel_space_point(point, &image_assets, &texture_atlas_assets);
+        assert_eq!(compute(Vec2::new(0.5, 0.5)), Ok(Vec2::new(1.5, 3.5)));
+        // The pixel is outside the texture atlas, but is still a valid pixel in the image.
+        assert_eq!(compute(Vec2::new(4.0, 2.5)), Err(Vec2::new(5.0, 1.5)));
+    }
+
+    #[test]
+    fn compute_pixel_space_point_for_texture_atlas_sprite_with_rect() {
+        let mut image_assets = Assets::<Image>::default();
+        let mut texture_atlas_assets = Assets::<TextureAtlasLayout>::default();
+
+        let image = image_assets.add(make_image(UVec2::new(5, 10)));
+        let texture_atlas = texture_atlas_assets.add(TextureAtlasLayout {
+            size: UVec2::new(5, 10),
+            textures: vec![URect::new(1, 1, 4, 4)],
+        });
+
+        let sprite = Sprite {
+            image,
+            anchor: Anchor::BottomLeft,
+            texture_atlas: Some(TextureAtlas {
+                layout: texture_atlas,
+                index: 0,
+            }),
+            // The rect is relative to the texture atlas sprite.
+            rect: Some(Rect::new(1.5, 1.5, 3.0, 3.0)),
+            ..Default::default()
+        };
+
+        let compute =
+            |point| sprite.compute_pixel_space_point(point, &image_assets, &texture_atlas_assets);
+        assert_eq!(compute(Vec2::new(0.5, 0.5)), Ok(Vec2::new(3.0, 3.5)));
+        // The pixel is outside the texture atlas, but is still a valid pixel in the image.
+        assert_eq!(compute(Vec2::new(4.0, 2.5)), Err(Vec2::new(6.5, 1.5)));
+    }
+
+    #[test]
+    fn compute_pixel_space_point_for_sprite_with_custom_size_and_rect() {
+        let mut image_assets = Assets::<Image>::default();
+        let texture_atlas_assets = Assets::<TextureAtlasLayout>::default();
+
+        let image = image_assets.add(make_image(UVec2::new(5, 10)));
+
+        let sprite = Sprite {
+            image,
+            custom_size: Some(Vec2::new(100.0, 50.0)),
+            rect: Some(Rect::new(0.0, 0.0, 5.0, 5.0)),
+            ..Default::default()
+        };
+
+        let compute =
+            |point| sprite.compute_pixel_space_point(point, &image_assets, &texture_atlas_assets);
+        assert_eq!(compute(Vec2::new(30.0, 15.0)), Ok(Vec2::new(4.0, 1.0)));
+        assert_eq!(compute(Vec2::new(-10.0, -15.0)), Ok(Vec2::new(2.0, 4.0)));
+        // The pixel is outside the texture atlas, but is still a valid pixel in the image.
+        assert_eq!(compute(Vec2::new(0.0, 35.0)), Err(Vec2::new(2.5, -1.0)));
     }
 }


### PR DESCRIPTION
I merged, and then added 2 commits on top. The first is a function to compute where in the texture a sprite point is. The second is rewriting the picking backend to take advantage of this. I tested this with the `sprite_picking` example and it seems to work quite well! Note this isn't just a move: I rewrote the logic. I've taken some of the logic from `crates\bevy_sprite\src\render\mod.rs:406` and mixed in some of my own ideas. Hopefully this is more clear and also handles more cases!

I haven't dug in to figuring out SpriteImageMode yet, so that might be the next step.

PS: I goofed and originally set it to merge to your main rather than your PR.